### PR TITLE
Add the csrf token to JS requests

### DIFF
--- a/gargoyle/templates/gargoyle/index.html
+++ b/gargoyle/templates/gargoyle/index.html
@@ -25,6 +25,20 @@
 
     <script src="{% url 'nexus:media' 'gargoyle' 'js/string_score.min.js' %}"></script>
     <script src="{% url 'nexus:media' 'gargoyle' 'js/gargoyle.js' %}"></script>
+    <script type="text/javascript">
+        function csrfSafeMethod(method) {
+            // these HTTP methods do not require CSRF protection
+            return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
+        }
+        $.ajaxSetup({
+            beforeSend: function(xhr, settings) {
+                if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
+                    xhr.setRequestHeader("X-CSRFToken", "{{csrf_token}}");
+                }
+            }
+        });
+    </script>
+
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
Add the csrf token to JS requests. This is needed when CSRF_COOKIE_HTTPONLY is enabled in the settings.