### PR TITLE
MVBE-8300: gargoyle gives 500

### DIFF
--- a/gargoyle/templatetags/gargoyle_helpers.py
+++ b/gargoyle/templatetags/gargoyle_helpers.py
@@ -6,7 +6,10 @@ gargoyle.templatetags.gargoyle_helpers
 :license: Apache License 2.0, see LICENSE for more details.
 """
 
-from django import template as template_base
+try:
+    from django.template import base as template_base
+except ImportError:
+    from django import template as template_base
 
 register = template_base.Library()
 


### PR DESCRIPTION
JIRA: https://vikingco.atlassian.net/browse/MVBE-8300

Reverted an import change, this will be released along with Django 1.9 instead.

This reverts https://github.com/vikingco/gargoyle/commit/9111b32e2ce1697a30f7f61818a78aaf5b9f6809